### PR TITLE
Use same port as signing service

### DIFF
--- a/terraform/compose_templates/signing_service.yml
+++ b/terraform/compose_templates/signing_service.yml
@@ -20,7 +20,7 @@ services:
       - dap-network
     ports:
       - "${SIGNING_SERVICE_SSH_PORT}:22"
-      - "${SIGNING_SERVICE_PORT}:5000"
+      - "${SIGNING_SERVICE_PORT}:${SIGNING_SERVICE_PORT}"
     environment:
       ZHSM: ${ZHSM}
       ZHSM_CREDENTIAL: ${ZHSM_CREDENTIAL}


### PR DESCRIPTION
Keep the signing service port (default 5002) the same instead of hard coding the target port within the docker compose.