### PR TITLE
feat: DAPCS-420: Include electrum ui for client in dap-blueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ terraform/fraud_detection_policy_service
 terraform/transaction_approval_policy_service
 terraform/signing_service
 *.egg-info
+electrum-data/

--- a/Deploy.md
+++ b/Deploy.md
@@ -771,8 +771,16 @@ Currently, only three userids (alice, bob, and charlie) can be used with a passw
 ```
 ./electrum_client.py broadcast <userid> <a raw transaction in hex>
 ```
-  
-#### Funding and transferring
+ 
+### Electrum UI
+
+The Electrum UI can be used instead of the CLI interface to do some simple operations such as receiving and sending bitcoin. You can run multiple instances at the same time for different wallets on different vnc ports. 
+
+```
+./run-electrum-gui.sh <vnc-port> <vnc-password>
+```
+ 
+### Funding and transferring
 
 After creating a user wallet and obtaining a new bitcoin address, you can use the address to obtain some test bitcoin from one of the following bitcoin faucet sites.
 

--- a/DigitalAssets-Electrum/electrum/gui/qt/paytoedit.py
+++ b/DigitalAssets-Electrum/electrum/gui/qt/paytoedit.py
@@ -218,8 +218,8 @@ class PayToEdit(CompletionTextEdit, ScanQRTextEdit, Logger):
         docHeight = self.document().size().height()
         h = docHeight * lineHeight + 11
         h = min(max(h, self.heightMin), self.heightMax)
-        self.setMinimumHeight(h)
-        self.setMaximumHeight(h)
+        self.setMinimumHeight(int(h))
+        self.setMaximumHeight(int(h))
         self.verticalScrollBar().hide()
 
     def qr_input(self):

--- a/DigitalAssets-Electrum/start_gui.sh
+++ b/DigitalAssets-Electrum/start_gui.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+NETWORK=--testnet
+VERBOSE="-V INFO"
+
+echo Using ${ELECTRUM_DATA} path
+
+mkdir -p /root/.vnc
+x11vnc -storepasswd ${VNC_PASSWORD} ~/.vnc/passwd
+Xvfb :1 -screen 0 1280x1024x16 &
+sleep 2
+x11vnc -forever -usepw -create -rfbport ${VNC_PORT} -display :1.0 &
+sleep 2
+
+export DISPLAY=:1.0
+./run_electrum ${NETWORK} ${VERBOSE} -D ${ELECTRUM_DATA}

--- a/entrypoints/entrypoint.sh
+++ b/entrypoints/entrypoint.sh
@@ -15,6 +15,12 @@ if [ ! -d /data ]; then
     mkdir /data
 fi
 
+if [ ${DAP_SERVICE} == ELECTRUMGUI ]; then
+    cd /git/dap-blueprint/DigitalAssets-Electrum
+    sh -c './start_gui.sh'
+    exit 0
+fi
+
 if [ ${DAP_SERVICE} == ELECTRUM ]; then
     cp supervisord-${DAP_SERVICE,,}.conf ${SUPERVISORD_CONF}
     /usr/local/bin/supervisord

--- a/run-electrum-gui.sh
+++ b/run-electrum-gui.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+export $(cat .env | grep -v ^#)
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: run-electrum-gui.sh <port> <vnc-password>"
+    exit 1
+fi
+
+VNC_PORT=$1
+VNC_PASSWORD=$2
+NAME=electrumgui-${VNC_PORT}
+
+mkdir -p electrum-data/wallets
+
+docker stop ${NAME}
+docker rm ${NAME}
+docker run -v `pwd`/electrum-data:/data -v `pwd`/.dap.tmp:/git/dap-blueprint/DigitalAssets-Electrum/.dap.tmp -e DAP_HOST=${DAP_HOST} -e RHSSO_HOST=${RHSSO_HOST} -e DAP_SERVICE=ELECTRUMGUI -p ${VNC_PORT}:${VNC_PORT} -e VNC_PASSWORD=${VNC_PASSWORD} -e VNC_PORT=${VNC_PORT} --network dap-network --name ${NAME} -d dap-base


### PR DESCRIPTION
https://jsw.ibm.com/browse/DAPCS-420

Include electrum gui support with pyqt5 to dap-blueprint.  For PYQT5 to work, we require a newer version of the library that isn't available within Ubuntu 18.04 (bionic). Therefore, we are updating to 22.04 with Python 10.  Includes scripts that can be used to easily startup an electrum gui with VNC running such that the user can connect to the specified VNC port. Can run multiple docker contains (electrum, electrum gui wallet 1, electrum gui wallet 2, etc). 
 